### PR TITLE
Add command to get last command sent to the tree

### DIFF
--- a/mcu/README.md
+++ b/mcu/README.md
@@ -8,6 +8,7 @@ Local serial connection sequence:
 
 ### Setup
 
+- Install `clang-format`
 - Copy `src/wifi_config.h.sample` to `src/wifi_config.h` and fill in the appropriate values.
 - Copy `src/ota_config.h.sample` to `src/ota_config.h` and fill in the appropriate values.
 

--- a/mcu/format.sh
+++ b/mcu/format.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+clang-format -i src/*

--- a/mcu/src/commands.cpp
+++ b/mcu/src/commands.cpp
@@ -92,6 +92,10 @@ void unpack_colors_from_data(uint8_t *data, uint8_t num_colors,
   }
 }
 
+// TODO - there's no need to have a uint16_t
+// for the number of colors provided - we don't have more than
+// 2^8 pixels.
+//
 // fills the strip by repeating the provided color(s)
 // uses gamma correction
 void fill_pattern_cmd(uint8_t *data, uint16_t len, Adafruit_NeoPixel *strip) {

--- a/mcu/src/commands.h
+++ b/mcu/src/commands.h
@@ -10,7 +10,8 @@ enum command {
   FILL_PATTERN,
   RAINBOW,
   RAINBOW_CYCLE,
-  THEATER_CHASE
+  THEATER_CHASE,
+  READBACK = 255
 };
 
 struct Packet {

--- a/tools/commands.py
+++ b/tools/commands.py
@@ -5,3 +5,4 @@ fill_color=3
 fill_pattern=4
 rainbow=5
 rainbow_cycle=6
+readback=255

--- a/tools/readback.py
+++ b/tools/readback.py
@@ -1,0 +1,19 @@
+import socket
+import struct
+from config import UDP_IP, UDP_PORT
+import commands
+
+command = [commands.readback]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.sendto(bytes(command), (UDP_IP, UDP_PORT))
+
+# 512 matches UDP_BUFFER_SIZE
+data, address = sock.recvfrom(512)
+data_iter = struct.iter_unpack("B", data)
+
+ints = list(data_iter)
+print(len(ints))
+# only print out the first ten
+print(ints[:10])
+


### PR DESCRIPTION
Perhaps not the most elegant solution, but it will send back to the requesting client the last command packet the tree received.

This can be useful for when the client starts and needs to know what sequence the tree is currently running.