### PR TITLE
Delay with udp

### DIFF
--- a/mcu/src/commands.cpp
+++ b/mcu/src/commands.cpp
@@ -121,7 +121,7 @@ void fill_pattern_cmd(uint8_t *data, uint16_t len, Adafruit_NeoPixel *strip) {
 bool theater_chase_cmd(uint8_t *data, Adafruit_NeoPixel *strip) {
   uint8_t repeat = data[0];
   uint32_t c = strip->Color(data[1], data[2], data[3]);
-  theater_chase(c, 20, strip);
+  theater_chase(c, 200, strip);
   return repeat;
 }
 

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -117,6 +117,8 @@ void loop() {
       Udp.write(packet, UDP_BUFFER_SIZE);
       Udp.endPacket();
       Udp.flush();
+      // must make a new call to parsePacket
+      delay_with_udp(10);
     } else {
       uint16_t command_packet_length = Udp.read(packet, UDP_BUFFER_SIZE);
       if (command_packet_length) {

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -85,6 +85,7 @@ bool process_packet(Packet *packet) {
                          &strip);
 }
 
+// return true if a packet arrived during the delay call
 bool delay_with_udp(unsigned long ms) {
   unsigned long current = millis();
   unsigned long future = current + ms;
@@ -107,6 +108,8 @@ void setup() {
 
 void loop() {
   ArduinoOTA.handle();
+  // available is supposed to be called after parsePacket, which is handled
+  // in delay_with_udp
   if (Udp.available()) {
     if (Udp.peek() == READBACK) {
       // special command to send back to the client

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -92,7 +92,7 @@ bool delay_with_udp(unsigned long ms) {
   while (millis() < future) {
     if (Udp.parsePacket())
       return true;
-    delay(1);
+    yield();
   }
 
   return false;

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -87,8 +87,7 @@ bool process_packet(Packet *packet) {
 
 // return true if a packet arrived during the delay call
 bool delay_with_udp(unsigned long ms) {
-  unsigned long current = millis();
-  unsigned long future = current + ms;
+  unsigned long future = millis() + ms;
 
   while (millis() < future) {
     if (Udp.parsePacket())

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -117,8 +117,9 @@ void loop() {
       Udp.write(packet, UDP_BUFFER_SIZE);
       Udp.endPacket();
       Udp.flush();
-      // must make a new call to parsePacket
-      delay_with_udp(10);
+      // must make a new call to parsePacket before calling available() again
+      Udp.parsePacket();
+      yield();
     } else {
       uint16_t command_packet_length = Udp.read(packet, UDP_BUFFER_SIZE);
       if (command_packet_length) {

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -4,10 +4,10 @@
 #include <ESP8266WiFi.h>
 #include <WiFiUdp.h>
 
-#include "utils.h"
 #include "commands.h"
 #include "ota_config.h"
 #include "sequences.h"
+#include "utils.h"
 #include "wifi_config.h"
 
 #define PIN D1
@@ -89,8 +89,9 @@ bool delay_with_udp(unsigned long ms) {
   unsigned long current = millis();
   unsigned long future = current + ms;
 
-  while(millis() < future) {
-    if (Udp.parsePacket()) return true;
+  while (millis() < future) {
+    if (Udp.parsePacket())
+      return true;
     delay(1);
   }
 
@@ -106,7 +107,7 @@ void setup() {
 
 void loop() {
   ArduinoOTA.handle();
-  if (Udp.parsePacket()) {
+  if (Udp.available()) {
     if (Udp.peek() == READBACK) {
       // special command to send back to the client
       // the last packet received, i.e. the running command
@@ -125,6 +126,6 @@ void loop() {
   } else if (repeat_packet) {
     process_packet(&latest_packet);
   } else {
-    delay(10);
+    delay_with_udp(10);
   }
 }

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -4,6 +4,7 @@
 #include <ESP8266WiFi.h>
 #include <WiFiUdp.h>
 
+#include "utils.h"
 #include "commands.h"
 #include "ota_config.h"
 #include "sequences.h"
@@ -82,6 +83,18 @@ void start_udp() { Udp.begin(UDP_PORT); }
 bool process_packet(Packet *packet) {
   return process_command(packet->command, packet->data, packet->data_len,
                          &strip);
+}
+
+bool delay_with_udp(unsigned long ms) {
+  unsigned long current = millis();
+  unsigned long future = current + ms;
+
+  while(millis() < future) {
+    if (Udp.parsePacket()) return true;
+    delay(1);
+  }
+
+  return false;
 }
 
 void setup() {

--- a/mcu/src/sequences.cpp
+++ b/mcu/src/sequences.cpp
@@ -1,3 +1,4 @@
+#include "utils.h"
 #include "sequences.h"
 
 /*
@@ -72,7 +73,7 @@ void rainbow(uint8_t wait, Adafruit_NeoPixel *strip) {
       strip->setPixelColor(i, wheel((i + j) & 255, strip));
     }
     strip->show();
-    delay(wait);
+    if(delay_with_udp(wait)) return;
   }
 }
 

--- a/mcu/src/sequences.cpp
+++ b/mcu/src/sequences.cpp
@@ -1,5 +1,5 @@
-#include "utils.h"
 #include "sequences.h"
+#include "utils.h"
 
 /*
  * Many of these sequences are from examples
@@ -73,7 +73,8 @@ void rainbow(uint8_t wait, Adafruit_NeoPixel *strip) {
       strip->setPixelColor(i, wheel((i + j) & 255, strip));
     }
     strip->show();
-    if(delay_with_udp(wait)) return;
+    if (delay_with_udp(wait))
+      return;
   }
 }
 

--- a/mcu/src/sequences.cpp
+++ b/mcu/src/sequences.cpp
@@ -61,7 +61,8 @@ void color_wipe(uint32_t c, uint8_t wait, Adafruit_NeoPixel *strip) {
   for (uint16_t i = 0; i < strip->numPixels(); i++) {
     strip->setPixelColor(i, c);
     strip->show();
-    delay(wait);
+    if (delay_with_udp(wait))
+      return;
   }
 }
 
@@ -88,7 +89,8 @@ void rainbow_cycle(uint8_t wait, Adafruit_NeoPixel *strip) {
           i, wheel(((i * 256 / strip->numPixels()) + j) & 255, strip));
     }
     strip->show();
-    delay(wait);
+    if (delay_with_udp(wait))
+      return;
   }
 }
 
@@ -100,7 +102,8 @@ void theater_chase(uint32_t c, uint8_t wait, Adafruit_NeoPixel *strip) {
         strip->setPixelColor(i + q, c); // turn every third pixel on
       }
       strip->show();
-      delay(wait);
+      if (delay_with_udp(wait))
+        return;
 
       for (uint16_t i = 0; i < strip->numPixels(); i = i + 3) {
         strip->setPixelColor(i + q, 0); // turn every third pixel off
@@ -118,8 +121,8 @@ void theater_chase_rainbow(uint8_t wait, Adafruit_NeoPixel *strip) {
             i + q, wheel((i + j) % 255, strip)); // turn every third pixel on
       }
       strip->show();
-
-      delay(wait);
+      if (delay_with_udp(wait))
+        return;
 
       for (uint16_t i = 0; i < strip->numPixels(); i = i + 3) {
         strip->setPixelColor(i + q, 0); // turn every third pixel off

--- a/mcu/src/utils.h
+++ b/mcu/src/utils.h
@@ -1,0 +1,2 @@
+
+bool delay_with_udp(unsigned long);


### PR DESCRIPTION
Closes #8.

Note: This doesn't resolve watchdog resets when driving the pixels at a high rate, it only increases the responsiveness when sending new commands.