### PR TITLE
ESPHome firmware.

### DIFF
--- a/esphome/.gitignore
+++ b/esphome/.gitignore
@@ -1,0 +1,2 @@
+secrets.yaml
+.esphome

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -1,0 +1,24 @@
+# ESPHome firmware
+
+This folder contains an ESPHome rewrite of the tree firmware so it can pair directly with Home Assistant. The light entity exposes brightness, color, and a set of effects that mirror the original UDP commands (rainbow, rainbow cycle, theater chase) plus a few extra seasonal twinkles.
+
+## Setup
+
+1. Install the ESPHome add-on in Home Assistant or the [ESPHome CLI](https://esphome.io/guides/getting_started_command_line.html).
+2. Copy `esphome/secrets.yaml.sample` to `esphome/secrets.yaml` and fill in your Wi-Fi credentials, static IP (or remove the `manual_ip` block in `tree.yaml` to use DHCP), and new API/OTA keys (`esphome random` can generate these).
+3. Adjust `substitutions` in `esphome/tree.yaml` if your pin or LED count differs (defaults: 106 LEDs on GPIO18).
+
+## Flashing
+
+- **First flash (USB):** `esphome run esphome/tree.yaml --device /dev/ttyUSB0`
+- **OTA updates:** After the first flash, run `esphome run esphome/tree.yaml` to push updates over Wi-Fi.
+
+The device will expose a fallback AP named `NeoPixel Tree Fallback` if it cannot join Wi-Fi; connect to it to supply credentials.
+
+## Home Assistant controls
+
+You will get a single light entity named `NeoPixel Tree`. Use the standard brightness and color controls, and pick routines from the effect list:
+- Rainbow Flow
+- Random Sparkle
+
+Additional telemetry entities are provided for Wi-Fi RSSI, uptime, IP address, and firmware version, plus a restart button.

--- a/esphome/secrets.yaml.sample
+++ b/esphome/secrets.yaml.sample
@@ -1,0 +1,15 @@
+# Replace the values below with your own and save as secrets.yaml
+wifi_ssid: "YourSSID"
+wifi_password: "your_wifi_password"
+
+# Static network info (comment out the manual_ip block in tree.yaml if you prefer DHCP)
+static_ip: 192.168.1.123
+gateway: 192.168.1.1
+subnet: 255.255.255.0
+
+# Fallback AP shown if Wi-Fi fails
+fallback_ap_password: "tree-ap-pass"
+
+# Generate strong keys: `esphome random`
+api_encryption_key: "api_key_generated_by_esphome_random"
+ota_password: "ota_password_generated_by_esphome_random"

--- a/esphome/tree.yaml
+++ b/esphome/tree.yaml
@@ -1,0 +1,83 @@
+substitutions:
+  name: neopixel-tree
+  friendly_name: "NeoPixel Tree"
+  num_leds: "106"
+  data_pin: "18"
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  project:
+    name: twstokes.neopixel_tree
+    version: "2.0.0-esphome"
+  comment: "ESPHome rewrite of the NeoPixel Tree firmware"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+logger:
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  power_save_mode: none
+  manual_ip:
+    static_ip: !secret static_ip
+    gateway: !secret gateway
+    subnet: !secret subnet
+  ap:
+    ssid: "${friendly_name} Fallback"
+    password: !secret fallback_ap_password
+
+mdns:
+  disabled: false
+
+light:
+  - platform: neopixelbus
+    id: tree_light
+    name: "${friendly_name}"
+    pin: GPIO${data_pin}
+    type: GRB
+    variant: WS2812
+    num_leds: ${num_leds}
+    gamma_correct: 2.8
+    default_transition_length: 0.3s
+    effects:
+      - addressable_rainbow:
+          name: "Rainbow Flow"
+          speed: 8
+          width: 30
+      - addressable_random_twinkle:
+          name: "Random Sparkle"
+          twinkle_probability: 3%
+          progress_interval: 6ms
+
+sensor:
+  - platform: uptime
+    name: "${friendly_name} Uptime"
+  - platform: wifi_signal
+    name: "${friendly_name} WiFi RSSI"
+    update_interval: 60s
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "${friendly_name} IP"
+    ssid:
+      name: "${friendly_name} SSID"
+  - platform: version
+    name: "${friendly_name} ESPHome Version"
+
+button:
+  - platform: restart
+    name: "${friendly_name} Restart"


### PR DESCRIPTION
Adds firmware version for ESPHome.

Command used to overwrite the previous Arduino firmware from `esphome` directory using OTA:

```
python ~/.platformio/packages/framework-arduinoespressif32/tools/espota.py -i [hostname or ip of tree] -p 3232 -a [current ota password] -f .esphome/build/neopixel-tree/.pioenvs/neopixel-tree/firmware.bin
```

Subsequent OTA uploads can be executed via `esphome run tree.yaml`.